### PR TITLE
Updated to work with Python 3.9

### DIFF
--- a/bin/compose-mode
+++ b/bin/compose-mode
@@ -1,3 +1,3 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 from compose_mode import _main
 _main.main()

--- a/compose_mode/__init__.py
+++ b/compose_mode/__init__.py
@@ -1,4 +1,4 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-__version__ = '0.5.6'
+__version__ = '0.6.0'

--- a/setup.py
+++ b/setup.py
@@ -8,13 +8,13 @@ import compose_mode
 
 install_requires = [
     'docker-compose >= 1.7',
-    'PyYAML >= 3.10, < 4',
+    'PyYAML >= 3.10',
 ]
 
 classifiers = [
     'Development Status :: 2 - Pre-Alpha',
     'License :: OSI Approved :: MIT License',
-    'Programming Language :: Python :: 2.7',
+    'Programming Language :: Python :: 3.9',
 ]
 
 with open(os.path.join(os.path.dirname(__file__), 'README.md')) as readme_file:


### PR DESCRIPTION
Python 3.9 won't build older versions of `PyYaml` so use the latest one.  
I've only tested by building wheels for the package and installing into my project. Seems to work ok.